### PR TITLE
Converting pathnames to strings

### DIFF
--- a/Support/shared/lib/tm/executor.rb
+++ b/Support/shared/lib/tm/executor.rb
@@ -200,7 +200,7 @@ module TextMate
         names = [ path.realpath, ENV['TM_FILEPATH'], path.basename, File.basename(ENV['TM_FILEPATH']) ]
 
         pathRegexp = Regexp.new(paths.map { |path| Regexp.escape("file://#{path}") }.join('|'))
-        nameRegexp = Regexp.new(names.map { |name| Regexp.escape(name) }.join('|'))
+        nameRegexp = Regexp.new(names.map { |name| Regexp.escape(name.to_s) }.join('|'))
 
         str = str.dup
         if ENV.has_key? "TM_FILE_IS_UNTITLED"


### PR DESCRIPTION
Hi,

I know TM only supports system Ruby but, adding this small patch (5 chars) allows to Run a _C/C++_ program with any version of Ruby 1.9 or 2.0 while keeping everything working with 1.8.7.

Without it, I get a `no implicit conversion of Pathname into String (TypeError)`.

Have a nice day :wink:
