### PR TITLE
Updating request_color() to call "System Events" from osascript

### DIFF
--- a/Support/shared/lib/ui.rb
+++ b/Support/shared/lib/ui.rb
@@ -71,8 +71,8 @@ module TextMate
         string = $1 * 2 + $2 * 2 + $3 * 2 if string =~ /^(.)(.)(.)$/
         def_col = ' default color {' + string.scan(/../).map { |i| i.hex * 257 }.join(",") + '}'
         begin
-          col = %x{osascript -e 'tell app "AppleScript Runner" to activate' \
-                             -e 'tell app "AppleScript Runner" to choose color#{def_col}'}
+          col = %x{osascript -e 'tell app "System Events" to activate' \
+                             -e 'tell app "System Events" to choose color#{def_col}'}
         rescue
           return col = string
         end


### PR DESCRIPTION
The "Applescript Runner" process is unsupported in Mac OS X Mavericks, so the osascript call for 'choose color' is now sent to the "System Events" background process.
