### PR TITLE
Change html_header() to call ruby18 instead of TM_RUBY

### DIFF
--- a/Support/shared/lib/webpreview.sh
+++ b/Support/shared/lib/webpreview.sh
@@ -16,7 +16,7 @@ html_header() {
 		3)	export WINDOW_TITLE="$1"; export PAGE_TITLE="$2"; export SUB_TITLE="$3";;
 	esac
 
-	"${TM_RUBY:-ruby}" -r"$TM_SUPPORT_PATH/lib/web_preview.rb" <<-'RUBY'
+	ruby18 -r"$TM_SUPPORT_PATH/lib/web_preview.rb" <<-'RUBY'
 		puts html_head(
 			:window_title	=> ENV['WINDOW_TITLE'],
 			:page_title		=> ENV['PAGE_TITLE'],


### PR DESCRIPTION
Bundle support ruby codes are currently have not been updated for ruby 2.0,
so anything using bundle support ruby codes they must be run on ruby 1.8.

This change fixes https://github.com/textmate/bundle-support.tmbundle/issues/13
