### PR TITLE
copy output not replace origin text

### DIFF
--- a/Support/shared/lib/tm/executor.rb
+++ b/Support/shared/lib/tm/executor.rb
@@ -148,7 +148,7 @@ module TextMate
             io << fix_links_to_unsaved(error)
           end
 
-          io << '<div class="controls"><a href="#" onclick="copyOutput(document.getElementById(\'_executor_output\'))">copy output</a>'
+          io << '<div class="controls"><div id="copytime"></div>&nbsp;&nbsp;<a href="#" onclick="copyOutput(document.getElementById(\'_executor_output\'))">copy output</a>'
           
           options[:controls].each_key {|key| io << " | <a href=\"javascript:TextMate.system('#{options[:controls][key]}')\">#{key}</a>"}
           
@@ -292,7 +292,7 @@ HTML
     cmd = TextMate.system('/usr/bin/pbcopy', function(){});
     cmd.write(output);
     cmd.close();
-    element.innerText = 'output copied to clipboard';
+    document.getElementById('copytime').innerText = 'output copied to clipboard at: ' + new Date();
   }
   
   </script>
@@ -363,6 +363,11 @@ HTML
     div#exception_report pre.snippet {
       margin:4pt;
       padding:4pt;
+    }
+    div#copytime {
+      font-size: 10pt;
+      float:left;
+      display:inline;
     }
   </style>
 HTML


### PR DESCRIPTION
some time, copy output will failed,
this patch keep the origin text, enable copy it again.