### PR TITLE
Let ^C terminate whole process group

### DIFF
--- a/Support/shared/lib/tm/process.rb
+++ b/Support/shared/lib/tm/process.rb
@@ -69,11 +69,11 @@ end
 
 def kill_and_wait(pid)
   begin
-    Process.kill("INT", pid)
+    Process.kill("-INT", pid)
     20.times { return unless pid_exists?(pid); sleep 0.02 }
-    Process.kill("TERM", pid)
+    Process.kill("-TERM", pid)
     20.times { return unless pid_exists?(pid); sleep 0.02 }
-    Process.kill("KILL", pid)
+    Process.kill("-KILL", pid)
   rescue
     # process doesn't exist anymore
   end
@@ -118,6 +118,7 @@ module TextMate
 
           options[:env].each { |k,v| ENV[k] = v } unless options[:env].nil?
           Dir.chdir(options[:chdir]) if options.has_key?(:chdir) and File.directory?(options[:chdir])
+          ::Process.setsid
           exec(*cmd.compact)
         }
 


### PR DESCRIPTION
In opposite what what written in f50a13922d this represents real behavior of
shell, which executes commands in separate process group (aka session) and ^C
sends signals to whole process group, effectively not leaving any leftover
stray processes running.

This is done by:

1. Calling `::Process.setsid` starting new session and making the forked process
   a process group leader.

2. Using `::Process.kill("-SIG")` prefixing signal with "-" which effectively
   sends signal to process group.

Now TextMate is finally able to properly tear down `go run` and similar wrapper
processes.