### PR TITLE
Executor output: Highlight line if file reference link is clicked.

### DIFF
--- a/Support/shared/lib/tm/executor.rb
+++ b/Support/shared/lib/tm/executor.rb
@@ -254,17 +254,20 @@ module TextMate
             end
 
             info = relative.gsub('&', '&amp;').gsub('<', '&lt;').gsub('"', '&quot;')
-            return "<a href=\"txmt://open?#{parms.join '&'}\" title=\"#{info}\">#{file + prefix}</a> #{htmlize message}<br>\n"
+            return "<div class='line'><a href=\"txmt://open?#{parms.join '&'}\" title=\"#{info}\">#{file + prefix}</a> #{htmlize message}<br></div>\n"
           end
         end
 
-        return htmlize(fix_links_to_unsaved(line))
+        return "<div class='line'>" + htmlize(fix_links_to_unsaved(line)) + "</div>\n"
       end
 
       def process_output_wrapper(io)
         io << <<-HTML
 
-<script type="text/javascript" charset="utf-8">document.body.addEventListener("keydown", press, false);</script>
+<script type="text/javascript" charset="utf-8">
+  document.body.addEventListener("keydown", press, false);
+  document.body.addEventListener("click", click)
+</script>
 
 <!-- first box containing version info and script output -->
 <pre>
@@ -287,6 +290,18 @@ HTML
      }
   }
   
+  function click(evt) {
+    if (event.target.tagName == 'A') {
+      var line = event.target;
+      while (line && !line.classList.contains('line')) line = line.parentElement;
+      if (line) {
+        Array.from(document.getElementsByClassName('line current')).forEach(function (el) {
+          el.classList.remove('current');
+        });
+        line.classList.add('current');
+      }
+    }
+  }
   function copyOutput(element) {
     output = element.innerText.replace(/(?:^| ) +/mg, function(match, offset, s) { return match.replace(/ /g, ' '); });
     cmd = TextMate.system('/usr/bin/pbcopy', function(){});
@@ -344,7 +359,11 @@ HTML
       -khtml-nbsp-mode: space;
       -khtml-line-break: after-white-space;
     }
-
+    
+    div#_executor_output .line.current {
+      background: rgba(255, 240, 80, 0.25);
+      outline: 1px solid rgba(255, 240, 80, 0.25);
+    }
     div#_executor_output .out {  
 
     }


### PR DESCRIPTION
Motivation: Make it easier to keep track of the file reference link you just clicked on: You click on a link, focus changes to the associated source document, and now you’re wondering: “What’s the exact error message associated with this line again?” If the output window contains a lot of links it can be hard to find the exact one you just clicked to read the associated message.

I experimented with highlighting the link only, but highlighting the whole line somehow works better (especially for quickly looking at the associated message).

Screenshot: 
![bildschirmfoto 2016-08-08 um 14 11 51](https://cloud.githubusercontent.com/assets/244158/17479305/18c3a9e0-5d72-11e6-9dbb-0beb3240c047.png)