### PR TITLE
Fix the complete method for Ruby 2.x

### DIFF
--- a/Support/shared/lib/ui.rb
+++ b/Support/shared/lib/ui.rb
@@ -121,8 +121,8 @@ module TextMate
       # and the result of the block inserted as a snippet
       def complete(choices, options = {}, &block) #  :yields: choice
         fork do
-          STDOUT.reopen(open('/dev/null'))
-          STDERR.reopen(open('/dev/null'))
+          STDOUT.reopen(open('/dev/null', 'w'))
+          STDERR.reopen(open('/dev/null', 'w'))
 
           unless options.has_key? :initial_filter
             require "#{ENV['TM_SUPPORT_PATH']}/lib/current_word.rb"


### PR DESCRIPTION
Without this fix, the following error occurs:

```
`reopen': <STDOUT> can't change access mode from "w" to "r" (ArgumentError)
```